### PR TITLE
Prevent qt from phoning home

### DIFF
--- a/5.9-android/Dockerfile
+++ b/5.9-android/Dockerfile
@@ -57,11 +57,16 @@ RUN dpkg --add-architecture i386 && apt update && apt full-upgrade -y && apt ins
 
 COPY extract-qt-installer.sh /tmp/qt/
 
+# Prevent QT from phoning home
+ENV http_proxy=http://127.0.0.1/
+
 # Download & unpack Qt toolchains & clean
 RUN curl -Lo /tmp/qt/installer.run "https://download.qt.io/official_releases/qt/$(echo "${QT_VERSION}" | cut -d. -f 1-2)/${QT_VERSION}/qt-opensource-linux-x64-${QT_VERSION}.run" \
     && QT_CI_PACKAGES=qt.$(echo "${QT_VERSION}" | tr -d .).android_armv7 /tmp/qt/extract-qt-installer.sh /tmp/qt/installer.run "$QT_PATH" \
     && find "${QT_PATH}" -mindepth 1 -maxdepth 1 ! -name "${QT_VERSION}" -exec echo 'Cleaning Qt SDK: {}' \; -exec rm -r '{}' \; \
     && rm -rf /tmp/qt
+
+ENV http_proxy=
 
 # Download & unpack android SDK
 RUN curl -Lo /tmp/sdk-tools.zip 'https://dl.google.com/android/repository/sdk-tools-linux-3859397.zip' \

--- a/5.9-android/extract-qt-installer.sh
+++ b/5.9-android/extract-qt-installer.sh
@@ -106,4 +106,4 @@ Controller.prototype.FinishedPageCallback = function() {
 EOF
 
 chmod u+x $INSTALLER
-QT_QPA_PLATFORM=minimal $INSTALLER -v --script $SCRIPT
+QT_QPA_PLATFORM=minimal $INSTALLER -v --proxy --script $SCRIPT


### PR DESCRIPTION
For version < 5.14, your dockerfiles are not working anymore (as for 2021-01 , if you try the 5.9 android version, you'll see that it remain stuck on the "credential" page with no way to skip)

The installer phone to qt home EVEN with this version that previously did NOT require an account, and now, it does.

But you can prevent this by preventing the QT installer to browse to the net, append --proxy to the qt installer.run and export http_proxy=http://127.0.0.1/ in your dockerfile
The qt offline installer will behave as expected.

