### PR TITLE
Reactivate qt.5.4 and others

### DIFF
--- a/5.4-android/Dockerfile
+++ b/5.4-android/Dockerfile
@@ -1,0 +1,75 @@
+# Minimal docker container to build project
+# Image: rabits/qt:5.4-android
+
+FROM ubuntu:14.04
+MAINTAINER Rabit <home@rabits.org> (@rabits)
+
+ENV DEBIAN_FRONTEND noninteractive
+ENV QT_PATH /opt/Qt
+ENV QT_ANDROID ${QT_PATH}/5.4/android_armv7
+ENV ANDROID_HOME /opt/android-sdk-linux
+ENV ANDROID_SDK_ROOT ${ANDROID_HOME}
+ENV ANDROID_NDK_ROOT /opt/android-ndk
+ENV ANDROID_NDK_TOOLCHAIN_PREFIX arm-linux-androideabi
+ENV ANDROID_NDK_TOOLCHAIN_VERSION 4.9
+ENV ANDROID_NDK_HOST linux-x86_64
+ENV ANDROID_NDK_PLATFORM android-21
+ENV ANDROID_NDK_TOOLS_PREFIX ${ANDROID_NDK_TOOLCHAIN_PREFIX}
+ENV QMAKESPEC android-g++
+ENV PATH ${PATH}:${QT_ANDROID}/bin:${PATH}:${ANDROID_HOME}/tools:${ANDROID_HOME}/platform-tools
+
+# Install updates & requirements:
+#  * git, openssh-client, ca-certificates - clone & build
+#  * curl, p7zip - to download & unpack Qt bundle
+#  * make, default-jdk, ant - basic build requirements
+#  * libsm6, libice6, libxext6, libxrender1, libfontconfig1 - dependencies of Qt bundle run-file
+#  * libc6:i386, libncurses5:i386, libstdc++6:i386, libz1:i386 - dependencides of android sdk binaries
+RUN sudo dpkg --add-architecture i386 && apt-get -qq update && apt-get -qq dist-upgrade && apt-get install -qq -y --no-install-recommends \
+    git \
+    openssh-client \
+    ca-certificates \
+    make \
+    default-jdk \
+    ant \
+    curl \
+    p7zip \
+    libsm6 \
+    libice6 \
+    libxext6 \
+    libxrender1 \
+    libfontconfig1 \
+    libc6:i386 \
+    libncurses5:i386 \
+    libstdc++6:i386 \
+    libz1:i386 \
+    && apt-get -qq clean
+
+# Download & unpack Qt 5.4 toolchains & clean
+RUN mkdir -p /tmp/qt \
+    && curl -Lo /tmp/qt/installer.run 'http://download.qt.io/official_releases/qt/5.4/5.4.2/qt-opensource-linux-x64-android-5.4.2.run' \
+    && chmod +x /tmp/qt/installer.run && /tmp/qt/installer.run --dump-binary-data -o /tmp/qt/data \
+    && mkdir $QT_PATH && cd $QT_PATH \
+    && 7zr x /tmp/qt/data/qt.54.android_armv7/5.4.2-0qt5_essentials.7z > /dev/null \
+    && 7zr x /tmp/qt/data/qt.54.android_armv7/5.4.2-0qt5_addons.7z > /dev/null \
+    && /tmp/qt/installer.run --runoperation QtPatch linux $QT_ANDROID qt5 \
+    && rm -rf /tmp/qt
+
+# Download & unpack android SDK
+RUN mkdir /tmp/android && curl -Lo /tmp/android/sdk.tgz 'http://dl.google.com/android/android-sdk_r24.4.1-linux.tgz' \
+    && tar --no-same-owner -xf /tmp/android/sdk.tgz -C /opt \
+    && rm -rf /tmp/android && echo "y" | android update sdk -u -a -t tools,platform-tools,build-tools-21.1.2,$ANDROID_NDK_PLATFORM
+
+# Download & unpack android NDK
+RUN mkdir /tmp/android && cd /tmp/android && curl -Lo ndk.bin 'http://dl.google.com/android/ndk/android-ndk-r10e-linux-x86_64.bin' \
+    && chmod +x ndk.bin && ./ndk.bin > /dev/null && mv android-ndk-r10e $ANDROID_NDK_ROOT && chmod -R +rX $ANDROID_NDK_ROOT \
+    && rm -rf /tmp/android
+
+# Reconfigure locale
+RUN locale-gen en_US.UTF-8 && dpkg-reconfigure locales
+
+# Add group & user
+RUN groupadd -r user && useradd --create-home --gid user user && echo 'user ALL=NOPASSWD: ALL' > /etc/sudoers.d/user
+
+USER user
+WORKDIR /home/user
+ENV HOME /home/user

--- a/5.4-android/Dockerfile
+++ b/5.4-android/Dockerfile
@@ -46,7 +46,7 @@ RUN sudo dpkg --add-architecture i386 && apt-get -qq update && apt-get -qq dist-
 
 # Download & unpack Qt 5.4 toolchains & clean
 RUN mkdir -p /tmp/qt \
-    && curl -Lo /tmp/qt/installer.run 'http://download.qt.io/official_releases/qt/5.4/5.4.2/qt-opensource-linux-x64-android-5.4.2.run' \
+    && curl -Lo /tmp/qt/installer.run 'https://download.qt.io/new_archive/qt/5.4/5.4.2/qt-opensource-linux-x64-android-5.4.2.run' \
     && chmod +x /tmp/qt/installer.run && /tmp/qt/installer.run --dump-binary-data -o /tmp/qt/data \
     && mkdir $QT_PATH && cd $QT_PATH \
     && 7zr x /tmp/qt/data/qt.54.android_armv7/5.4.2-0qt5_essentials.7z > /dev/null \

--- a/5.4-desktop/Dockerfile
+++ b/5.4-desktop/Dockerfile
@@ -1,0 +1,52 @@
+# Minimal docker container to build project
+# Image: rabits/qt:5.4-desktop
+
+FROM ubuntu:14.04
+MAINTAINER Rabit <home@rabits.org> (@rabits)
+
+ENV DEBIAN_FRONTEND noninteractive
+ENV QT_PATH /opt/Qt
+ENV QT_DESKTOP $QT_PATH/5.4/gcc_64
+ENV PATH $QT_DESKTOP/bin:$PATH
+
+# Install updates & requirements:
+#  * git, openssh-client, ca-certificates - clone & build
+#  * curl, p7zip - to download & unpack Qt bundle
+#  * build-essential, pkg-config, libgl1-mesa-dev - basic Qt build requirements
+#  * libsm6, libice6, libxext6, libxrender1, libfontconfig1 - dependencies of Qt bundle run-file
+RUN apt-get -qq update && apt-get -qq dist-upgrade && apt-get install -qq -y --no-install-recommends \
+    git \
+    openssh-client \
+    ca-certificates \
+    curl \
+    p7zip \
+    build-essential \
+    pkg-config \
+    libgl1-mesa-dev \
+    libsm6 \
+    libice6 \
+    libxext6 \
+    libxrender1 \
+    libfontconfig1 \
+    && apt-get -qq clean
+
+# Download & unpack Qt 5.4 toolchains & clean
+RUN mkdir -p /tmp/qt \
+    && curl -Lo /tmp/qt/installer.run 'http://download.qt.io/official_releases/qt/5.4/5.4.2/qt-opensource-linux-x64-5.4.2.run' \
+    && chmod 755 /tmp/qt/installer.run && /tmp/qt/installer.run --dump-binary-data -o /tmp/qt/data \
+    && mkdir $QT_PATH && cd $QT_PATH \
+    && 7zr x /tmp/qt/data/qt.54.gcc_64/5.4.2-0qt5_essentials.7z > /dev/null \
+    && 7zr x /tmp/qt/data/qt.54.gcc_64/5.4.2-0qt5_addons.7z > /dev/null \
+    && 7zr x /tmp/qt/data/qt.54.gcc_64/5.4.2-0icu_53_1_ubuntu_11_10_64.7z > /dev/null \
+    && /tmp/qt/installer.run --runoperation QtPatch linux $QT_DESKTOP qt5 \
+    && rm -rf /tmp/qt
+
+# Reconfigure locale
+RUN locale-gen en_US.UTF-8 && dpkg-reconfigure locales
+
+# Add group & user
+RUN groupadd -r user && useradd --create-home --gid user user && echo 'user ALL=NOPASSWD: ALL' > /etc/sudoers.d/user
+
+USER user
+WORKDIR /home/user
+ENV HOME /home/user

--- a/5.6-android/Dockerfile
+++ b/5.6-android/Dockerfile
@@ -1,12 +1,12 @@
 # Minimal docker container to build project
-# Image: rabits/qt:5.7-android
+# Image: rabits/qt:5.6-android
 
 FROM ubuntu:16.04
 MAINTAINER Rabit <home@rabits.org> (@rabits)
 
 ENV DEBIAN_FRONTEND noninteractive
 ENV QT_PATH /opt/Qt
-ENV QT_ANDROID ${QT_PATH}/5.7/android_armv7
+ENV QT_ANDROID ${QT_PATH}/5.6/android_armv7
 ENV ANDROID_HOME /opt/android-sdk-linux
 ENV ANDROID_SDK_ROOT ${ANDROID_HOME}
 ENV ANDROID_NDK_ROOT /opt/android-ndk
@@ -49,9 +49,9 @@ RUN dpkg --add-architecture i386 && apt-get -qq update && apt-get -qq dist-upgra
 
 COPY extract-qt-installer.sh /tmp/qt/
 
-# Download & unpack Qt 5.7 toolchains & clean
-RUN curl -Lo /tmp/qt/installer.run 'https://download.qt.io/new_archive/qt/5.7/5.7.1/qt-opensource-linux-x64-android-5.7.1.run' \
-    && QT_CI_PACKAGES=qt.57.android_armv7 /tmp/qt/extract-qt-installer.sh /tmp/qt/installer.run "$QT_PATH" \
+# Download & unpack Qt 5.6 toolchains & clean
+RUN curl -Lo /tmp/qt/installer.run 'https://download.qt.io/new_archive/qt/5.6/5.6.3/qt-opensource-linux-x64-android-5.6.3.run' \
+    && QT_CI_PACKAGES=qt.563.android_armv7 /tmp/qt/extract-qt-installer.sh /tmp/qt/installer.run "$QT_PATH" \
     && find "$QT_PATH" -mindepth 1 -maxdepth 1 ! -name '5.*' -exec echo 'Cleaning Qt SDK: {}' \; -exec rm -r '{}' \; \
     && rm -rf /tmp/qt
 

--- a/5.6-android/extract-qt-installer.sh
+++ b/5.6-android/extract-qt-installer.sh
@@ -1,0 +1,109 @@
+#!/bin/sh -e
+# QT-CI Project
+# License: Apache-2.0
+# https://github.com/benlau/qtci
+
+if [ $# -lt 2 ];
+then
+    echo extract-qt-installer qt-installer output_path
+    exit -1
+fi
+
+INSTALLER=$1
+OUTPUT=$2
+SCRIPT="$(mktemp /tmp/tmp.XXXXXXXXX)"
+PACKAGES=$QT_CI_PACKAGES
+
+cat <<EOF > $SCRIPT
+function Controller() {
+    installer.installationFinished.connect(function() {
+        gui.clickButton(buttons.NextButton);
+    });
+
+    installer.setMessageBoxAutomaticAnswer("OverwriteTargetDirectory", QMessageBox.Yes);
+    installer.setMessageBoxAutomaticAnswer("installationErrorWithRetry", QMessageBox.Ignore);
+
+}
+
+Controller.prototype.WelcomePageCallback = function() {
+    console.log("Welcome Page");
+    gui.clickButton(buttons.NextButton, 3000);
+}
+
+Controller.prototype.CredentialsPageCallback = function() {
+    gui.clickButton(buttons.CommitButton);
+}
+
+Controller.prototype.ComponentSelectionPageCallback = function() {
+    console.log("Select components");
+
+    function trim(str) {
+        return str.replace(/^ +/,"").replace(/ *$/,"");
+    }
+
+    var widget = gui.currentPageWidget();
+
+    var packages = trim("$PACKAGES").split(",");
+    if (packages.length > 0 && packages[0] !== "") {
+        widget.deselectAll();
+        for (var i in packages) {
+            var pkg = trim(packages[i]);
+            console.log("Select " + pkg);
+            widget.selectComponent(pkg);
+        }
+    } else {
+       console.log("Use default component list");
+    }
+
+    gui.clickButton(buttons.NextButton);
+}
+
+Controller.prototype.IntroductionPageCallback = function() {
+    console.log("Introduction Page");
+    console.log("Retrieving meta information from remote repository");
+    gui.clickButton(buttons.NextButton);
+}
+
+
+Controller.prototype.TargetDirectoryPageCallback = function() {
+    console.log("Set target installation page: $OUTPUT");
+    var widget = gui.currentPageWidget();
+
+    if (widget != null) {
+        widget.TargetDirectoryLineEdit.setText("$OUTPUT");
+    }
+
+    gui.clickButton(buttons.NextButton);
+
+}
+
+Controller.prototype.LicenseAgreementPageCallback = function() {
+    console.log("Accept license agreement");
+    var widget = gui.currentPageWidget();
+
+    if (widget != null) {
+        widget.AcceptLicenseRadioButton.setChecked(true);
+    }
+
+    gui.clickButton(buttons.NextButton);
+
+}
+
+Controller.prototype.ReadyForInstallationPageCallback = function() {
+    console.log("Ready to install");
+    gui.clickButton(buttons.CommitButton);
+}
+
+Controller.prototype.FinishedPageCallback = function() {
+    var widget = gui.currentPageWidget();
+
+    if (widget.LaunchQtCreatorCheckBoxForm) {
+        // No this form for minimal platform
+        widget.LaunchQtCreatorCheckBoxForm.launchQtCreatorCheckBox.setChecked(false);
+    }
+    gui.clickButton(buttons.FinishButton);
+}
+EOF
+
+chmod u+x $INSTALLER
+QT_QPA_PLATFORM=minimal $INSTALLER -v --script $SCRIPT

--- a/5.6-desktop/Dockerfile
+++ b/5.6-desktop/Dockerfile
@@ -1,25 +1,27 @@
 # Minimal docker container to build project
-# Image: rabits/qt:5.4-desktop
+# Image: rabits/qt:5.6-desktop
 
-FROM ubuntu:14.04
+FROM ubuntu:16.04
 MAINTAINER Rabit <home@rabits.org> (@rabits)
 
 ENV DEBIAN_FRONTEND noninteractive
 ENV QT_PATH /opt/Qt
-ENV QT_DESKTOP $QT_PATH/5.4/gcc_64
+ENV QT_DESKTOP $QT_PATH/5.6/gcc_64
 ENV PATH $QT_DESKTOP/bin:$PATH
 
 # Install updates & requirements:
 #  * git, openssh-client, ca-certificates - clone & build
-#  * curl, p7zip - to download & unpack Qt bundle
+#  * locales, sudo - useful to set utf-8 locale & sudo usage
+#  * curl - to download Qt bundle
 #  * build-essential, pkg-config, libgl1-mesa-dev - basic Qt build requirements
-#  * libsm6, libice6, libxext6, libxrender1, libfontconfig1 - dependencies of Qt bundle run-file
+#  * libsm6, libice6, libxext6, libxrender1, libfontconfig1, libdbus-1-3 - dependencies of the Qt bundle run-file
 RUN apt-get -qq update && apt-get -qq dist-upgrade && apt-get install -qq -y --no-install-recommends \
     git \
     openssh-client \
     ca-certificates \
+    locales \
+    sudo \
     curl \
-    p7zip \
     build-essential \
     pkg-config \
     libgl1-mesa-dev \
@@ -28,23 +30,21 @@ RUN apt-get -qq update && apt-get -qq dist-upgrade && apt-get install -qq -y --n
     libxext6 \
     libxrender1 \
     libfontconfig1 \
+    libdbus-1-3 \
     && apt-get -qq clean
 
-# Download & unpack Qt 5.4 toolchains & clean
-RUN mkdir -p /tmp/qt \
-    && curl -Lo /tmp/qt/installer.run 'https://download.qt.io/new_archive/qt/5.4/5.4.2/qt-opensource-linux-x64-5.4.2.run' \
-    && chmod 755 /tmp/qt/installer.run && /tmp/qt/installer.run --dump-binary-data -o /tmp/qt/data \
-    && mkdir $QT_PATH && cd $QT_PATH \
-    && 7zr x /tmp/qt/data/qt.54.gcc_64/5.4.2-0qt5_essentials.7z > /dev/null \
-    && 7zr x /tmp/qt/data/qt.54.gcc_64/5.4.2-0qt5_addons.7z > /dev/null \
-    && 7zr x /tmp/qt/data/qt.54.gcc_64/5.4.2-0icu_53_1_ubuntu_11_10_64.7z > /dev/null \
-    && /tmp/qt/installer.run --runoperation QtPatch linux $QT_DESKTOP qt5 \
+COPY extract-qt-installer.sh /tmp/qt/
+
+# Download & unpack Qt 5.6 toolchains & clean
+RUN curl -Lo /tmp/qt/installer.run 'https://download.qt.io/new_archive/qt/5.6/5.6.3/qt-opensource-linux-x64-5.6.3.run' \
+    && QT_CI_PACKAGES=qt.563.gcc_64 /tmp/qt/extract-qt-installer.sh /tmp/qt/installer.run "$QT_PATH" \
+    && find "$QT_PATH" -mindepth 1 -maxdepth 1 ! -name '5.*' -exec echo 'Cleaning Qt SDK: {}' \; -exec rm -r '{}' \; \
     && rm -rf /tmp/qt
 
 # Reconfigure locale
 RUN locale-gen en_US.UTF-8 && dpkg-reconfigure locales
 
-# Add group & user
+# Add group & user + sudo
 RUN groupadd -r user && useradd --create-home --gid user user && echo 'user ALL=NOPASSWD: ALL' > /etc/sudoers.d/user
 
 USER user

--- a/5.6-desktop/extract-qt-installer.sh
+++ b/5.6-desktop/extract-qt-installer.sh
@@ -1,0 +1,109 @@
+#!/bin/sh -e
+# QT-CI Project
+# License: Apache-2.0
+# https://github.com/benlau/qtci
+
+if [ $# -lt 2 ];
+then
+    echo extract-qt-installer qt-installer output_path
+    exit -1
+fi
+
+INSTALLER=$1
+OUTPUT=$2
+SCRIPT="$(mktemp /tmp/tmp.XXXXXXXXX)"
+PACKAGES=$QT_CI_PACKAGES
+
+cat <<EOF > $SCRIPT
+function Controller() {
+    installer.installationFinished.connect(function() {
+        gui.clickButton(buttons.NextButton);
+    });
+
+    installer.setMessageBoxAutomaticAnswer("OverwriteTargetDirectory", QMessageBox.Yes);
+    installer.setMessageBoxAutomaticAnswer("installationErrorWithRetry", QMessageBox.Ignore);
+
+}
+
+Controller.prototype.WelcomePageCallback = function() {
+    console.log("Welcome Page");
+    gui.clickButton(buttons.NextButton, 3000);
+}
+
+Controller.prototype.CredentialsPageCallback = function() {
+    gui.clickButton(buttons.CommitButton);
+}
+
+Controller.prototype.ComponentSelectionPageCallback = function() {
+    console.log("Select components");
+
+    function trim(str) {
+        return str.replace(/^ +/,"").replace(/ *$/,"");
+    }
+
+    var widget = gui.currentPageWidget();
+
+    var packages = trim("$PACKAGES").split(",");
+    if (packages.length > 0 && packages[0] !== "") {
+        widget.deselectAll();
+        for (var i in packages) {
+            var pkg = trim(packages[i]);
+            console.log("Select " + pkg);
+            widget.selectComponent(pkg);
+        }
+    } else {
+       console.log("Use default component list");
+    }
+
+    gui.clickButton(buttons.NextButton);
+}
+
+Controller.prototype.IntroductionPageCallback = function() {
+    console.log("Introduction Page");
+    console.log("Retrieving meta information from remote repository");
+    gui.clickButton(buttons.NextButton);
+}
+
+
+Controller.prototype.TargetDirectoryPageCallback = function() {
+    console.log("Set target installation page: $OUTPUT");
+    var widget = gui.currentPageWidget();
+
+    if (widget != null) {
+        widget.TargetDirectoryLineEdit.setText("$OUTPUT");
+    }
+
+    gui.clickButton(buttons.NextButton);
+
+}
+
+Controller.prototype.LicenseAgreementPageCallback = function() {
+    console.log("Accept license agreement");
+    var widget = gui.currentPageWidget();
+
+    if (widget != null) {
+        widget.AcceptLicenseRadioButton.setChecked(true);
+    }
+
+    gui.clickButton(buttons.NextButton);
+
+}
+
+Controller.prototype.ReadyForInstallationPageCallback = function() {
+    console.log("Ready to install");
+    gui.clickButton(buttons.CommitButton);
+}
+
+Controller.prototype.FinishedPageCallback = function() {
+    var widget = gui.currentPageWidget();
+
+    if (widget.LaunchQtCreatorCheckBoxForm) {
+        // No this form for minimal platform
+        widget.LaunchQtCreatorCheckBoxForm.launchQtCreatorCheckBox.setChecked(false);
+    }
+    gui.clickButton(buttons.FinishButton);
+}
+EOF
+
+chmod u+x $INSTALLER
+QT_QPA_PLATFORM=minimal $INSTALLER -v --script $SCRIPT

--- a/5.7-android/Dockerfile
+++ b/5.7-android/Dockerfile
@@ -1,0 +1,76 @@
+# Minimal docker container to build project
+# Image: rabits/qt:5.7-android
+
+FROM ubuntu:16.04
+MAINTAINER Rabit <home@rabits.org> (@rabits)
+
+ENV DEBIAN_FRONTEND noninteractive
+ENV QT_PATH /opt/Qt
+ENV QT_ANDROID ${QT_PATH}/5.7/android_armv7
+ENV ANDROID_HOME /opt/android-sdk-linux
+ENV ANDROID_SDK_ROOT ${ANDROID_HOME}
+ENV ANDROID_NDK_ROOT /opt/android-ndk
+ENV ANDROID_NDK_TOOLCHAIN_PREFIX arm-linux-androideabi
+ENV ANDROID_NDK_TOOLCHAIN_VERSION 4.9
+ENV ANDROID_NDK_HOST linux-x86_64
+ENV ANDROID_NDK_PLATFORM android-21
+ENV ANDROID_NDK_TOOLS_PREFIX ${ANDROID_NDK_TOOLCHAIN_PREFIX}
+ENV QMAKESPEC android-g++
+ENV PATH ${PATH}:${QT_ANDROID}/bin:${PATH}:${ANDROID_HOME}/tools:${ANDROID_HOME}/platform-tools
+
+# Install updates & requirements:
+#  * git, openssh-client, ca-certificates - clone & build
+#  * locales, sudo - useful to set utf-8 locale & sudo usage
+#  * curl - to download Qt bundle
+#  * make, default-jdk, ant - basic build requirements
+#  * libsm6, libice6, libxext6, libxrender1, libfontconfig1, libdbus-1-3 - dependencies of Qt bundle run-file
+#  * libc6:i386, libncurses5:i386, libstdc++6:i386, libz1:i386 - dependencides of android sdk binaries
+RUN dpkg --add-architecture i386 && apt-get -qq update && apt-get -qq dist-upgrade && apt-get install -qq -y --no-install-recommends \
+    git \
+    openssh-client \
+    ca-certificates \
+    locales \
+    sudo \
+    curl \
+    make \
+    default-jdk \
+    ant \
+    libsm6 \
+    libice6 \
+    libxext6 \
+    libxrender1 \
+    libfontconfig1 \
+    libdbus-1-3 \
+    libc6:i386 \
+    libncurses5:i386 \
+    libstdc++6:i386 \
+    libz1:i386 \
+    && apt-get -qq clean
+
+COPY extract-qt-installer.sh /tmp/qt/
+
+# Download & unpack Qt 5.7 toolchains & clean
+RUN curl -Lo /tmp/qt/installer.run 'http://download.qt.io/official_releases/qt/5.7/5.7.1/qt-opensource-linux-x64-android-5.7.1.run' \
+    && QT_CI_PACKAGES=qt.57.android_armv7 /tmp/qt/extract-qt-installer.sh /tmp/qt/installer.run "$QT_PATH" \
+    && find "$QT_PATH" -mindepth 1 -maxdepth 1 ! -name '5.*' -exec echo 'Cleaning Qt SDK: {}' \; -exec rm -r '{}' \; \
+    && rm -rf /tmp/qt
+
+# Download & unpack android SDK
+RUN mkdir /tmp/android && curl -Lo /tmp/android/sdk.tgz 'http://dl.google.com/android/android-sdk_r24.4.1-linux.tgz' \
+    && tar --no-same-owner -xf /tmp/android/sdk.tgz -C /opt \
+    && rm -rf /tmp/android && echo "y" | android update sdk -u -a -t tools,platform-tools,build-tools-21.1.2,$ANDROID_NDK_PLATFORM
+
+# Download & unpack android NDK
+RUN mkdir /tmp/android && cd /tmp/android && curl -Lo ndk.bin 'http://dl.google.com/android/ndk/android-ndk-r10e-linux-x86_64.bin' \
+    && chmod +x ndk.bin && ./ndk.bin > /dev/null && mv android-ndk-r10e $ANDROID_NDK_ROOT && chmod -R +rX $ANDROID_NDK_ROOT \
+    && rm -rf /tmp/android
+
+# Reconfigure locale
+RUN locale-gen en_US.UTF-8 && dpkg-reconfigure locales
+
+# Add group & user
+RUN groupadd -r user && useradd --create-home --gid user user && echo 'user ALL=NOPASSWD: ALL' > /etc/sudoers.d/user
+
+USER user
+WORKDIR /home/user
+ENV HOME /home/user

--- a/5.7-android/extract-qt-installer.sh
+++ b/5.7-android/extract-qt-installer.sh
@@ -1,0 +1,109 @@
+#!/bin/sh -e
+# QT-CI Project
+# License: Apache-2.0
+# https://github.com/benlau/qtci
+
+if [ $# -lt 2 ];
+then
+    echo extract-qt-installer qt-installer output_path
+    exit -1
+fi
+
+INSTALLER=$1
+OUTPUT=$2
+SCRIPT="$(mktemp /tmp/tmp.XXXXXXXXX)"
+PACKAGES=$QT_CI_PACKAGES
+
+cat <<EOF > $SCRIPT
+function Controller() {
+    installer.installationFinished.connect(function() {
+        gui.clickButton(buttons.NextButton);
+    });
+
+    installer.setMessageBoxAutomaticAnswer("OverwriteTargetDirectory", QMessageBox.Yes);
+    installer.setMessageBoxAutomaticAnswer("installationErrorWithRetry", QMessageBox.Ignore);
+
+}
+
+Controller.prototype.WelcomePageCallback = function() {
+    console.log("Welcome Page");
+    gui.clickButton(buttons.NextButton, 3000);
+}
+
+Controller.prototype.CredentialsPageCallback = function() {
+    gui.clickButton(buttons.CommitButton);
+}
+
+Controller.prototype.ComponentSelectionPageCallback = function() {
+    console.log("Select components");
+
+    function trim(str) {
+        return str.replace(/^ +/,"").replace(/ *$/,"");
+    }
+
+    var widget = gui.currentPageWidget();
+
+    var packages = trim("$PACKAGES").split(",");
+    if (packages.length > 0 && packages[0] !== "") {
+        widget.deselectAll();
+        for (var i in packages) {
+            var pkg = trim(packages[i]);
+            console.log("Select " + pkg);
+            widget.selectComponent(pkg);
+        }
+    } else {
+       console.log("Use default component list");
+    }
+
+    gui.clickButton(buttons.NextButton);
+}
+
+Controller.prototype.IntroductionPageCallback = function() {
+    console.log("Introduction Page");
+    console.log("Retrieving meta information from remote repository");
+    gui.clickButton(buttons.NextButton);
+}
+
+
+Controller.prototype.TargetDirectoryPageCallback = function() {
+    console.log("Set target installation page: $OUTPUT");
+    var widget = gui.currentPageWidget();
+
+    if (widget != null) {
+        widget.TargetDirectoryLineEdit.setText("$OUTPUT");
+    }
+
+    gui.clickButton(buttons.NextButton);
+
+}
+
+Controller.prototype.LicenseAgreementPageCallback = function() {
+    console.log("Accept license agreement");
+    var widget = gui.currentPageWidget();
+
+    if (widget != null) {
+        widget.AcceptLicenseRadioButton.setChecked(true);
+    }
+
+    gui.clickButton(buttons.NextButton);
+
+}
+
+Controller.prototype.ReadyForInstallationPageCallback = function() {
+    console.log("Ready to install");
+    gui.clickButton(buttons.CommitButton);
+}
+
+Controller.prototype.FinishedPageCallback = function() {
+    var widget = gui.currentPageWidget();
+
+    if (widget.LaunchQtCreatorCheckBoxForm) {
+        // No this form for minimal platform
+        widget.LaunchQtCreatorCheckBoxForm.launchQtCreatorCheckBox.setChecked(false);
+    }
+    gui.clickButton(buttons.FinishButton);
+}
+EOF
+
+chmod u+x $INSTALLER
+QT_QPA_PLATFORM=minimal $INSTALLER -v --script $SCRIPT

--- a/5.7-desktop/Dockerfile
+++ b/5.7-desktop/Dockerfile
@@ -1,0 +1,52 @@
+# Minimal docker container to build project
+# Image: rabits/qt:5.7-desktop
+
+FROM ubuntu:16.04
+MAINTAINER Rabit <home@rabits.org> (@rabits)
+
+ENV DEBIAN_FRONTEND noninteractive
+ENV QT_PATH /opt/Qt
+ENV QT_DESKTOP $QT_PATH/5.7/gcc_64
+ENV PATH $QT_DESKTOP/bin:$PATH
+
+# Install updates & requirements:
+#  * git, openssh-client, ca-certificates - clone & build
+#  * locales, sudo - useful to set utf-8 locale & sudo usage
+#  * curl - to download Qt bundle
+#  * build-essential, pkg-config, libgl1-mesa-dev - basic Qt build requirements
+#  * libsm6, libice6, libxext6, libxrender1, libfontconfig1, libdbus-1-3 - dependencies of the Qt bundle run-file
+RUN apt-get -qq update && apt-get -qq dist-upgrade && apt-get install -qq -y --no-install-recommends \
+    git \
+    openssh-client \
+    ca-certificates \
+    locales \
+    sudo \
+    curl \
+    build-essential \
+    pkg-config \
+    libgl1-mesa-dev \
+    libsm6 \
+    libice6 \
+    libxext6 \
+    libxrender1 \
+    libfontconfig1 \
+    libdbus-1-3 \
+    && apt-get -qq clean
+
+COPY extract-qt-installer.sh /tmp/qt/
+
+# Download & unpack Qt 5.7 toolchains & clean
+RUN curl -Lo /tmp/qt/installer.run 'http://download.qt.io/official_releases/qt/5.7/5.7.1/qt-opensource-linux-x64-5.7.1.run' \
+    && QT_CI_PACKAGES=qt.57.gcc_64 /tmp/qt/extract-qt-installer.sh /tmp/qt/installer.run "$QT_PATH" \
+    && find "$QT_PATH" -mindepth 1 -maxdepth 1 ! -name '5.*' -exec echo 'Cleaning Qt SDK: {}' \; -exec rm -r '{}' \; \
+    && rm -rf /tmp/qt
+
+# Reconfigure locale
+RUN locale-gen en_US.UTF-8 && dpkg-reconfigure locales
+
+# Add group & user + sudo
+RUN groupadd -r user && useradd --create-home --gid user user && echo 'user ALL=NOPASSWD: ALL' > /etc/sudoers.d/user
+
+USER user
+WORKDIR /home/user
+ENV HOME /home/user

--- a/5.7-desktop/Dockerfile
+++ b/5.7-desktop/Dockerfile
@@ -36,7 +36,7 @@ RUN apt-get -qq update && apt-get -qq dist-upgrade && apt-get install -qq -y --n
 COPY extract-qt-installer.sh /tmp/qt/
 
 # Download & unpack Qt 5.7 toolchains & clean
-RUN curl -Lo /tmp/qt/installer.run 'http://download.qt.io/official_releases/qt/5.7/5.7.1/qt-opensource-linux-x64-5.7.1.run' \
+RUN curl -Lo /tmp/qt/installer.run 'https://download.qt.io/new_archive/qt/5.7/5.7.1/qt-opensource-linux-x64-5.7.1.run' \
     && QT_CI_PACKAGES=qt.57.gcc_64 /tmp/qt/extract-qt-installer.sh /tmp/qt/installer.run "$QT_PATH" \
     && find "$QT_PATH" -mindepth 1 -maxdepth 1 ! -name '5.*' -exec echo 'Cleaning Qt SDK: {}' \; -exec rm -r '{}' \; \
     && rm -rf /tmp/qt

--- a/5.7-desktop/extract-qt-installer.sh
+++ b/5.7-desktop/extract-qt-installer.sh
@@ -1,0 +1,109 @@
+#!/bin/sh -e
+# QT-CI Project
+# License: Apache-2.0
+# https://github.com/benlau/qtci
+
+if [ $# -lt 2 ];
+then
+    echo extract-qt-installer qt-installer output_path
+    exit -1
+fi
+
+INSTALLER=$1
+OUTPUT=$2
+SCRIPT="$(mktemp /tmp/tmp.XXXXXXXXX)"
+PACKAGES=$QT_CI_PACKAGES
+
+cat <<EOF > $SCRIPT
+function Controller() {
+    installer.installationFinished.connect(function() {
+        gui.clickButton(buttons.NextButton);
+    });
+
+    installer.setMessageBoxAutomaticAnswer("OverwriteTargetDirectory", QMessageBox.Yes);
+    installer.setMessageBoxAutomaticAnswer("installationErrorWithRetry", QMessageBox.Ignore);
+
+}
+
+Controller.prototype.WelcomePageCallback = function() {
+    console.log("Welcome Page");
+    gui.clickButton(buttons.NextButton, 3000);
+}
+
+Controller.prototype.CredentialsPageCallback = function() {
+    gui.clickButton(buttons.CommitButton);
+}
+
+Controller.prototype.ComponentSelectionPageCallback = function() {
+    console.log("Select components");
+
+    function trim(str) {
+        return str.replace(/^ +/,"").replace(/ *$/,"");
+    }
+
+    var widget = gui.currentPageWidget();
+
+    var packages = trim("$PACKAGES").split(",");
+    if (packages.length > 0 && packages[0] !== "") {
+        widget.deselectAll();
+        for (var i in packages) {
+            var pkg = trim(packages[i]);
+            console.log("Select " + pkg);
+            widget.selectComponent(pkg);
+        }
+    } else {
+       console.log("Use default component list");
+    }
+
+    gui.clickButton(buttons.NextButton);
+}
+
+Controller.prototype.IntroductionPageCallback = function() {
+    console.log("Introduction Page");
+    console.log("Retrieving meta information from remote repository");
+    gui.clickButton(buttons.NextButton);
+}
+
+
+Controller.prototype.TargetDirectoryPageCallback = function() {
+    console.log("Set target installation page: $OUTPUT");
+    var widget = gui.currentPageWidget();
+
+    if (widget != null) {
+        widget.TargetDirectoryLineEdit.setText("$OUTPUT");
+    }
+
+    gui.clickButton(buttons.NextButton);
+
+}
+
+Controller.prototype.LicenseAgreementPageCallback = function() {
+    console.log("Accept license agreement");
+    var widget = gui.currentPageWidget();
+
+    if (widget != null) {
+        widget.AcceptLicenseRadioButton.setChecked(true);
+    }
+
+    gui.clickButton(buttons.NextButton);
+
+}
+
+Controller.prototype.ReadyForInstallationPageCallback = function() {
+    console.log("Ready to install");
+    gui.clickButton(buttons.CommitButton);
+}
+
+Controller.prototype.FinishedPageCallback = function() {
+    var widget = gui.currentPageWidget();
+
+    if (widget.LaunchQtCreatorCheckBoxForm) {
+        // No this form for minimal platform
+        widget.LaunchQtCreatorCheckBoxForm.launchQtCreatorCheckBox.setChecked(false);
+    }
+    gui.clickButton(buttons.FinishButton);
+}
+EOF
+
+chmod u+x $INSTALLER
+QT_QPA_PLATFORM=minimal $INSTALLER -v --script $SCRIPT


### PR DESCRIPTION
Qt provides its "old" software version on its official download url in a new location. I have partially reverted the removal of 5.4 and 5.7 support and updated the urls in them. I have also added support for 5.6.3, because I needed that in another context. Tests have been run only in another context not on this changes.

This pull request is merely meant to point to the relocated official packages. Use to your liking.